### PR TITLE
Fade-up Elements with `infocus` directive

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -27,11 +27,30 @@ Vue.use( VueAnalytics, {
 
 Vue.config.productionTip = false;
 
+Vue.directive('infocus', {
+    isLiteral: true,
+    bind: (el, binding, vnode) => {
+        el.style.opacity = 0;
+    },
+    inserted: (el, binding, vnode) => {
+        const updateInView = () => {
+            const rect = el.getBoundingClientRect()
+            const inView = !((rect.top + rect.height < 0) || (rect.top > window.innerHeight - 180))
+            if (inView) {
+                el.classList.add(binding.value)
+                window.removeEventListener('scroll', updateInView)
+            }
+        }
+        window.addEventListener('scroll', updateInView)
+        updateInView()
+    }
+  });
+
 // Init app
 let app = new Vue(
 {
 	router,
-	store,
+    store,
 	render: (h) => h(Page),
 }
 ).$mount("#app");

--- a/src/app/modules/project/components/big_image.vue
+++ b/src/app/modules/project/components/big_image.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-wrapper">
+    <div class="section-wrapper" v-infocus="'fade-up'">
       <prismic-image :field="content.primary.image" />
 	</div>
 </template>

--- a/src/app/modules/project/components/carousel.vue
+++ b/src/app/modules/project/components/carousel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="carousel">
+    <div class="carousel" v-infocus="'fade-up'">
 		<div class="carousel-wrapper">
 			<p ref="status" class="carousel-status"></p>
 			<div ref="carousel" class="main-carousel" >

--- a/src/app/modules/project/components/two_col_text.vue
+++ b/src/app/modules/project/components/two_col_text.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-wrapper">
+    <div class="section-wrapper" v-infocus="'fade-up'">
     	<div class="container">
 
             <!-- Eyebrow -->

--- a/src/app/modules/project/components/two_col_two_row_text.vue
+++ b/src/app/modules/project/components/two_col_two_row_text.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-wrapper">
+    <div class="section-wrapper" v-infocus="'fade-up'">
     	<div class="container">
 	    		<div class="col-6 col-tablet-12 left-column">
 

--- a/src/app/modules/project/components/video.vue
+++ b/src/app/modules/project/components/video.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-wrapper">
+    <div class="section-wrapper" v-infocus="'fade-up'">
         <video autoplay="" muted="" loop="" playsinline="" preload="auto">
             <source class="" type="video/mp4" :src="content.primary.video.url">
         </video>

--- a/src/app/modules/shared/components/column.vue
+++ b/src/app/modules/shared/components/column.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-wrapper">
+    <div class="section-wrapper" v-infocus="'fade-up'">
     	<div class="container">
             <div class="col-12" v-if="content.primary.title[0]">
                 <h3

--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="section-wrapper">
+    <div class="section-wrapper" v-infocus="'fade-up'">
     	<div class="container pillar-wrapper">
 
             <!-- Pillar Large Heading -->
@@ -68,10 +68,7 @@ export default
 	// 	...
 	///////////////////////////////////////////////////////
 
-	"mounted": function()
-	{
-		// console.log( this.$props.content );
-	},
+	"mounted": function(){},
 
 	"destroyed": function(){},
 

--- a/src/assets/scss/_utils.scss
+++ b/src/assets/scss/_utils.scss
@@ -31,6 +31,21 @@
 	}
 }
 
+.fade-up {
+    animation: fadeUp .8s forwards;
+}
+
+@keyframes fadeUp {
+    0% {
+        transform: translateY(15px);
+        opacity: 0;
+    }
+    100% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
 //  #######################################################
 //  #   Padding
 //  #######################################################


### PR DESCRIPTION
Doing some Superbowl Sunday coding 🏈

Set up fade-up functionality for when elements enter the viewport. My approach was using a custom directive to apply to elements that need to fade-up. The directive is called `infocus` so the directive is applied like `v-infocus="'fade-up'"`. You can pass a class name to apply, i.e. `fade-up`, so you could theoretically do another transition like `slide-left` or something. This can be seen on the Projects or About page.

Please let me know if there's a better way to handle this! Wasn't sure if `main.js` was the best place to put the custom directive declaration. I would appreciate any feedback and am open to other approaches.

Closes #22 