### PR TITLE
Wired up Project text color to update on color shift

### DIFF
--- a/src/app/modules/project/components/carousel.vue
+++ b/src/app/modules/project/components/carousel.vue
@@ -110,7 +110,6 @@ export default
   font-family: GTWalsheim, sans-serif;
   font-weight: 100;
   font-size: 18px;
-  color: white;
   text-align: center;
   margin: 35px 0;
 }

--- a/src/app/modules/project/project.vue
+++ b/src/app/modules/project/project.vue
@@ -3,7 +3,7 @@
 
         <div
             v-if="content"
-            :class="[content.theme_type === 'Dark' ? 'dark-theme' : 'light-theme' ]"
+            :class="[themeType === 'Dark' ? 'dark-theme' : 'light-theme' ]"
             :style="{ backgroundColor: backgroundColor }"
         >
 
@@ -157,6 +157,9 @@ export default
         {
             return ( this.shouldColorShift ) ? this.content.color_shift : this.content.project_color;
         },
+        themeType() {
+            return ( this.shouldColorShift ) ? this.content.color_shift_theme_type : this.content.theme_type;
+        }
     },
 }
 </script>
@@ -186,7 +189,6 @@ export default
     font-size: 70px;
     margin: 4px 0 0;
     font-weight: 300;
-    color: white;
 
     @media (max-width: $bp-size-md) {
         font-size: 50px;

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -24,7 +24,7 @@ body
 */
 a
 {
-	color: $color-primary;
+	color: inherit;
 	text-decoration: none;
 
 	cursor: pointer;


### PR DESCRIPTION
On Project pages when the background color shift happens, the text color needed to update correspondingly. This PR makes sure the text color update happens properly.

To test, go the branch preview link and go to the West project page and confirm the text turns to black after the background color shift.