### PR TITLE
Fix rich text handling for pillar

### DIFF
--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -13,7 +13,7 @@
             <!-- Pillar Body -->
 	    	<div :class="[content.primary.full_width === 'Full Width' ? 'col-12' : 'col-8', 'container', 'col-tablet-12']">
                 <div class ="col-12" v-if="content.primary.rich_text">
-                    <p v-for="(richtext, index) in content.primary.rich_text" :key="index">{{ richtext.text }}</p>
+                    <p v-for="(richtext, index) in content.primary.rich_text" :key="index"><span v-html="htmlForRichText(richtext)"/></p>
                 </div>
 	    		<div
                     :class="['pillar-rich-text', content.primary.full_width === 'Full Width' && content.items.length === 4 ? 'col-3 four-up' : content.items.length === 3 ? 'col-4' : 'col-6 two-up', 'pad-8-top', 'col-tablet-12']"
@@ -120,7 +120,11 @@ export default
             // Reduce to an array of HTML'd spans and non-spans
             let html = richText.spans.reduce( (sum, span, i ) => {
                 // Create the HTML node from the span
-                sum.push( `<${span.type}>${richText.text.substring( span.start, span.end )}</${span.type}>` );
+                if (span.type === 'hyperlink') {
+                    sum.push( `<a href="${span.data.url}" target=${span.data.target}>${richText.text.substring( span.start, span.end )}</a>` );
+                } else {
+                    sum.push( `<${span.type}>${richText.text.substring( span.start, span.end )}</${span.type}>` );
+                }
                 // Add the next non-span. It'll either be text until the next span or if last span then til the end of entire string
                 let nextEnd = ( i < richText.spans.length - 1 ) ? richText.spans[i+1].start : richText.text.length;
                 sum.push( richText.text.substring( span.end, nextEnd ) );
@@ -209,4 +213,10 @@ export default
     margin-top: 50px;
 }
 
+</style>
+
+<style lang="scss">
+a {
+    text-decoration: underline;
+}
 </style>

--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -48,7 +48,12 @@
                         to show inline tags like bold, italic, etc.
                         The logic here is to detect if there are rich text spans,
                         and if there are, use the prismic-rich-text tag to handle parsing
-                        the rich text. -->
+                        the rich text.
+                        
+                        And this actually works, however one of the cases it doesn't is when
+                        there is an ordered list because it doesn't know what order context the
+                        item is in.
+                         -->
                         <!-- <template v-else-if="richtext.spans && richtext.spans[0]">
                             <prismic-rich-text class="section-description" :field="[richtext]" :key="index" />
                         </template> -->

--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -31,11 +31,27 @@
                         <img v-else-if="richtext.type === 'image'" :src="richtext.url" class="pillar-image image-on" :key="index" />
 
                         <!-- Link -->
-                        <template v-else-if="richtext.spans && richtext.spans[0]">
+                        <!-- Specificity needed to detect if link should look like a CTA -->
+                        <template
+                            v-else-if="
+                                richtext.spans &&
+                                richtext.spans[0] &&
+                                richtext.spans[0].type === 'hyperlink'&&
+                                richtext.spans[0].start === 0
+                            ">
                             <div v-if="richtext.spans[0].type === 'hyperlink' " :key="index" class=" column-cta cta-wrapper">
                                 <prismic-link class="cta" :field="richtext.spans[0].data">{{ richtext.text }}</prismic-link>
                             </div>
                         </template>
+<!-- 
+                        Since we are destructuring the rich-text, we need a way
+                        to show inline tags like bold, italic, etc.
+                        The logic here is to detect if there are rich text spans,
+                        and if there are, use the prismic-rich-text tag to handle parsing
+                        the rich text. -->
+                        <!-- <template v-else-if="richtext.spans && richtext.spans[0]">
+                            <prismic-rich-text class="section-description" :field="[richtext]" :key="index" />
+                        </template> -->
 
                         <!-- Heading -->
                         <h4 v-else-if="richtext.type === 'heading3'" :key="index" class="column-heading">

--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -60,17 +60,17 @@
 
                         <!-- Heading -->
                         <h4 v-else-if="richtext.type === 'heading3'" :key="index" class="column-heading">
-                            {{ richtext.text }}
+                            <span v-html="htmlForRichText(richtext)"/>
                         </h4>
 
                         <!-- List Item -->
                         <div v-else-if="richtext.type === 'list-item' || richtext.type === 'paragraph'" :key="index" class="column-body">
-                            {{ richtext.text }}
+                            <span v-html="htmlForRichText(richtext)"/>
                         </div>
 
                         <!-- Ordered List Item -->
                         <ul v-else-if="richtext.type === 'o-list-item'" :key="index" class="column-body">
-                            <li>{{index}}. {{ richtext.text }}</li>
+                            <li>{{index}}. <span v-html="htmlForRichText(richtext)"/></li>
                         </ul>
                     </template>
 	    		</div>
@@ -113,7 +113,23 @@ export default
 	"methods" : {
         isHoverImage: function (item) {
             return item.url && item.url.indexOf('-hover') !== -1;
-        }
+        },
+        htmlForRichText( richText ) {
+            // If no spans, then just return plain text
+            if( richText.spans.length == 0 ) return richText.text;
+            // Reduce to an array of HTML'd spans and non-spans
+            let html = richText.spans.reduce( (sum, span, i ) => {
+                // Create the HTML node from the span
+                sum.push( `<${span.type}>${richText.text.substring( span.start, span.end )}</${span.type}>` );
+                // Add the next non-span. It'll either be text until the next span or if last span then til the end of entire string
+                let nextEnd = ( i < richText.spans.length - 1 ) ? richText.spans[i+1].start : richText.text.length;
+                sum.push( richText.text.substring( span.end, nextEnd ) );
+                // Return newly appended array
+                return sum;
+            }, [] );
+            // Join HTML'd spans and non-spans together as one HTML string 
+            return html.join("");
+        },
     },
 	"computed" : {},
 }


### PR DESCRIPTION
This PR is both a temporary fix and an opened ended brainstorm about rich text handling.

- The temporary fix updates the specificity for detecting a CTA-style link ("Inquire Here"), which was previously too broad and was detecting anything that contained a rich text span thus causing things not to render properly or at all.
- The opened ended part is about the way we're currently handling rich text for the pillar. The issue is that currently rich text styling like bold/italics aren't showing up because the rich text field is being de-structured so we can apply custom properties. See the comment in the code for more info. I included a screenshot of my current solution to this issue which still has flaws.

You can reproduce the issue by going to the Workshops draft in Prismic and viewing the preview while running this branch locally and uncommenting the template code.

<img width="929" alt="Screen Shot 2019-03-17 at 8 49 26 PM" src="https://user-images.githubusercontent.com/14880569/54505738-68dd5080-48f6-11e9-970f-7982fe90fd1a.png">
