### PR TITLE
Removed underline on Say Hello link

### DIFF
--- a/src/app/modules/home/home.vue
+++ b/src/app/modules/home/home.vue
@@ -269,12 +269,12 @@ export default
 /*End Emoji Word Replacement*/
 
 .say-hello {
-  font-family: GTWalsheim, sans-serif;
   font-size: 18px;
   margin: 64px 0;
   text-align: center;
   color: $color-text;
   display: block;
+  text-decoration: none;
 }
 
 .say-hello-arrow {


### PR DESCRIPTION
Fixes this:
<img width="344" alt="Screen Shot 2019-03-20 at 7 10 59 PM" src="https://user-images.githubusercontent.com/14880569/54730066-f9f53700-4b43-11e9-9a58-94774770c251.png">

