### PR TITLE
Fix rich text span white space

### DIFF
--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -132,7 +132,8 @@ export default
                 return sum;
             }, [] );
             // Join HTML'd spans and non-spans together as one HTML string 
-            return html.join("");
+            let beginning = richText.text.substring(0, richText.spans[0].start);
+            return beginning + html.join("");
         },
     },
 	"computed" : {},
@@ -181,6 +182,10 @@ export default
 	}
 }
 
+.pillar-rich-text span {
+    white-space: pre-line;
+}
+
 .pillar-rich-text .image-off, .pillar-rich-text:hover .image-off + .image-on {
   display: none;
 }
@@ -216,7 +221,7 @@ export default
 </style>
 
 <style lang="scss">
-a {
+.pillar-wrapper a {
     text-decoration: underline;
 }
 </style>

--- a/src/app/modules/shared/components/pillar.vue
+++ b/src/app/modules/shared/components/pillar.vue
@@ -43,20 +43,6 @@
                                 <prismic-link class="cta" :field="richtext.spans[0].data">{{ richtext.text }}</prismic-link>
                             </div>
                         </template>
-<!-- 
-                        Since we are destructuring the rich-text, we need a way
-                        to show inline tags like bold, italic, etc.
-                        The logic here is to detect if there are rich text spans,
-                        and if there are, use the prismic-rich-text tag to handle parsing
-                        the rich text.
-                        
-                        And this actually works, however one of the cases it doesn't is when
-                        there is an ordered list because it doesn't know what order context the
-                        item is in.
-                         -->
-                        <!-- <template v-else-if="richtext.spans && richtext.spans[0]">
-                            <prismic-rich-text class="section-description" :field="[richtext]" :key="index" />
-                        </template> -->
 
                         <!-- Heading -->
                         <h4 v-else-if="richtext.type === 'heading3'" :key="index" class="column-heading">
@@ -182,7 +168,7 @@ export default
 	}
 }
 
-.pillar-rich-text span {
+.pillar-wrapper p span {
     white-space: pre-line;
 }
 
@@ -216,6 +202,10 @@ export default
 
 .column-cta {
     margin-top: 50px;
+}
+
+.cta {
+    text-decoration: none;
 }
 
 </style>


### PR DESCRIPTION
The selector for the `white-space: pre-line` was incorrect. This adds the correct selector, does some cleanup, and fixes the CTA from being underlined.